### PR TITLE
#32 검색 메인화면 상단 검색바, 필터뷰 기본 UI 구성

### DIFF
--- a/Projects/Cafe/Sources/App/AppCoordinatorView.swift
+++ b/Projects/Cafe/Sources/App/AppCoordinatorView.swift
@@ -29,6 +29,7 @@ struct AppCoordinatorView: View {
         )
       }
     }
+    .ignoresSafeArea(.keyboard)
   }
 }
 

--- a/Projects/Cafe/Sources/App/Main/Search/CafeMapCore.swift
+++ b/Projects/Cafe/Sources/App/Main/Search/CafeMapCore.swift
@@ -17,55 +17,103 @@ extension CLLocationCoordinate2D: Equatable {
 }
 
 struct CafeMapCore: ReducerProtocol {
+  enum FilterOrder: CaseIterable {
+    case runningTime
+    case outlet
+    case spaceSize
+    case personnel
+
+    var title: String {
+      switch self {
+      case .runningTime: return "영업시간"
+      case .outlet: return "콘센트"
+      case .spaceSize: return "공간크기"
+      case .personnel: return "인원"
+      }
+    }
+  }
+
   struct State: Equatable {
     // TODO: Default 위치 값 설정 예정.
     var region: CLLocationCoordinate2D = CLLocationCoordinate2D(latitude: 1, longitude: 1)
     var isCurrentButtonTapped: Bool = false
+    let filterOrders = FilterOrder.allCases
+    @BindingState var searchText = ""
   }
 
-  enum Action: Equatable {
+  enum Action: Equatable, BindableAction {
+    case binding(BindingAction<State>)
     case currentLocationButtonTapped
     case requestAuthorization
     case currentLocationResponse(TaskResult<CLLocationCoordinate2D>)
     case fetchCurrentLocation
     case currentButtonToFalse
+    case filterOrderMenuClicked(FilterOrder)
+    case searchTextFieldTyped(text: String)
+    case searchTextFieldClearButtonClicked
+    case searchTextSubmitted
   }
 
   @Dependency(\.locationManager) private var locationManager
 
-  func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
-    switch action {
-    case .currentButtonToFalse:
-          state.isCurrentButtonTapped = false
-          return .none
+  var body: some ReducerProtocolOf<Self> {
+    BindingReducer()
 
-    case .fetchCurrentLocation:
-      return .run { send in
-        await send(
-          .currentLocationResponse(
-            TaskResult { try await locationManager.fetchCurrentLocation() }
+    Reduce { state, action in
+      switch action {
+      case .currentButtonToFalse:
+        state.isCurrentButtonTapped = false
+        return .none
+
+      case .fetchCurrentLocation:
+        return .run { send in
+          await send(
+            .currentLocationResponse(
+              TaskResult { try await locationManager.fetchCurrentLocation() }
+            )
           )
-        )
-      }
+        }
 
-    case let .currentLocationResponse(.success(currentLocation)):
-      state.region = currentLocation
-      return .none
+      case let .currentLocationResponse(.success(currentLocation)):
+        state.region = currentLocation
+        return .none
 
-    case let .currentLocationResponse(.failure(error)):
-      debugPrint(error)
-      return .none
+      case let .currentLocationResponse(.failure(error)):
+        debugPrint(error)
+        return .none
 
-    case .currentLocationButtonTapped:
-      state.isCurrentButtonTapped = true
-      return .run { send in
-        await send(.fetchCurrentLocation)
-      }
+      case .currentLocationButtonTapped:
+        state.isCurrentButtonTapped = true
+        return .run { send in
+          await send(.fetchCurrentLocation)
+        }
 
-    case .requestAuthorization:
-      locationManager.requestAuthorization()
-      return .run { send in
-        await send(.fetchCurrentLocation)
+      case .requestAuthorization:
+        locationManager.requestAuthorization()
+        return .run { send in
+          await send(.fetchCurrentLocation)
+        }
+
+      case .filterOrderMenuClicked:
+        // TODO: 필터 메뉴에 따른 이벤트 처리 필요
+        return .none
+
+      case .searchTextFieldTyped(let text):
+        state.searchText = text
+        return .none
+
+      case .searchTextFieldClearButtonClicked:
+        state.searchText = ""
+        return .none
+
+      case .searchTextSubmitted:
+        guard !state.searchText.trimmingCharacters(in: .whitespaces).isEmpty
+        else { return .none }
+        // TODO: 카페 검색 요청 필요
+        return .none
+
+      default:
+        return .none
       }
     }
   }

--- a/Projects/Cafe/Sources/App/Main/Search/CafeMapView.swift
+++ b/Projects/Cafe/Sources/App/Main/Search/CafeMapView.swift
@@ -6,9 +6,9 @@
 //  Copyright © 2023 com.cafe. All rights reserved.
 //
 
-import SwiftUI
-import NMapsMap
 import ComposableArchitecture
+import NMapsMap
+import SwiftUI
 
 struct CafeMapView: View {
   let store: StoreOf<CafeMapCore>
@@ -45,35 +45,84 @@ struct CafeMapView: View {
                 y: geometry.size.height/1.7
               )
           }
+          .navigationBarHidden(true)
         }
         .onAppear {
           viewStore.send(.requestAuthorization)
         }
       }
+      .ignoresSafeArea(.keyboard)
     }
   }
 }
 
 extension CafeMapView {
   var header: some View {
-    HStack(spacing: 8) {
-      ForEach(["영업중", "혼잡도낮은순", "가까운순", "추천순"], id: \.self) { status in
-        Button {
-        } label: {
-          Text("\(status)")
-            .font(.subheadline)
-            .foregroundColor(.black)
-            .lineLimit(1)
-            .padding(EdgeInsets(top: 7, leading: 12, bottom: 7, trailing: 12))
-            .overlay {
-              RoundedRectangle(cornerRadius: 20)
-                .stroke(Color.gray, lineWidth: 1)
-            }
+    WithViewStore(store) { viewStore in
+      VStack(spacing: 0) {
+        searchTextField
+        orderFilterView
+      }
+    }
+  }
+
+  var searchTextField: some View {
+    WithViewStore(store) { viewStore in
+      ZStack {
+        TextField(
+          "🔍  지역, 지하철로 검색",
+          text: viewStore.binding(\.$searchText)
+        )
+        .frame(height: 35)
+        .padding(.leading, 5)
+        .padding(.trailing, 25)
+        .overlay {
+          RoundedRectangle(cornerRadius: 5)
+            .stroke(.gray, lineWidth: 1)
+        }
+        .onSubmit {
+          viewStore.send(.searchTextSubmitted)
+        }
+
+        HStack {
+          Spacer()
+          Button {
+            viewStore.send(.searchTextFieldClearButtonClicked)
+          } label: {
+            Image(systemName: "xmark.circle.fill")
+              .foregroundColor(.gray)
+              .padding(.trailing, 5)
+          }
         }
       }
-      Spacer()
+      .padding(.horizontal, 16)
     }
-    .padding()
+  }
+
+  var orderFilterView: some View {
+    WithViewStore(store) { viewStore in
+      ScrollView(.horizontal) {
+        HStack(spacing: 8) {
+          ForEach(viewStore.filterOrders, id: \.self) { order in
+            Button {
+              viewStore.send(.filterOrderMenuClicked(order))
+            } label: {
+              Text(order.title)
+                .font(.subheadline)
+                .foregroundColor(.black)
+                .lineLimit(1)
+                .padding(EdgeInsets(top: 7, leading: 12, bottom: 7, trailing: 12))
+                .overlay {
+                  RoundedRectangle(cornerRadius: 20)
+                    .stroke(.gray, lineWidth: 1)
+                }
+                .frame(height: 60)
+            }
+          }
+        }
+        .padding(.horizontal, 16)
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## ☕️ PR 요약
- 상단 검색바 UI 구성 및 텍스트 입력 후 검색 로직 구성
  - BindingState 사용해서 텍스트필드에 입력되는 텍스트 정보를 실시간으로 searchTextFieldText와 바인딩
- figma 참고에서 필터 메뉴 리스트 이름 수정 및 필터 뷰 수평 스크롤 가능하게 UI 수정
  - todo : 필터 메뉴 선택 시 세부 필터 설정 UI 추가 개발 필요, (디자인가이드가 없어서 러프하게 구성했습니다.)
- 검색 화면 상단 여백이 보이는 문제 수정 (navigationBarHidden true)
- keyboard 올라올 시, 하단 탭바, 하단 지도 sheet 화면이 위로 올라가는 문제 수정 (.ignoresSafeArea(.keyboard))


## 📸 ScreenShot
<div>
<img src="https://github.com/YAPP-Github/22nd-iOS-Team-1-iOS/assets/4410021/c040b660-c6d9-4108-b61e-71c0ea6ad0fc" width="200">
<img src="https://github.com/YAPP-Github/22nd-iOS-Team-1-iOS/assets/4410021/5d2ec582-b659-43b3-8691-dcf216629ee4" width="200">
</div>

##### ✅ PR check list(PR 요청시 확인후 삭제해주세요)

```
- commit message가 적절한지 확인해주세요.
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 가능한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
```



#### Linked Issue

close #32 
