### PR TITLE
[UI] #51 카페 검색결과 상세페이지 파일 추가 및 헤더, 메뉴화면 기본 구조 구정

### DIFF
--- a/Projects/Coffice/Project.swift
+++ b/Projects/Coffice/Project.swift
@@ -11,7 +11,7 @@ let project = Project.app(
   iOSTargetVersion: iOSTargetVersion,
   infoPlist: [
     "CFBundleShortVersionString": "1.0.0", // 앱의 출시 버전
-    "CFBundleVersion": "2", // 앱의 빌드 버전 (테스트 플라이트 배포시 빌드 버전 up 필요)
+    "CFBundleVersion": "3", // 앱의 빌드 버전 (테스트 플라이트 배포시 빌드 버전 up 필요)
     "CFBundleDisplayName": "coffice", // 사용자에게 보여질 앱의 이름
     "UILaunchStoryboardName": "LaunchScreen",
     "UIInterfaceOrientation": ["UIInterfaceOrientationPortrait"],

--- a/Projects/Coffice/Sources/App/Main/SavedList/SavedListScreenCore.swift
+++ b/Projects/Coffice/Sources/App/Main/SavedList/SavedListScreenCore.swift
@@ -13,10 +13,12 @@ struct SearchScreen: ReducerProtocol {
   enum State: Equatable {
     /// 메인 페이지
     case cafeMap(CafeMapCore.State)
+    case cafeSearchDetail(CafeSearchDetail.State)
   }
 
   enum Action: Equatable {
     case cafeMap(CafeMapCore.Action)
+    case cafeSearchDetail(CafeSearchDetail.Action)
   }
 
   var body: some ReducerProtocolOf<SearchScreen> {
@@ -25,6 +27,13 @@ struct SearchScreen: ReducerProtocol {
       action: /Action.cafeMap
     ) {
       CafeMapCore()
+    }
+
+    Scope(
+      state: /State.cafeSearchDetail,
+      action: /Action.cafeSearchDetail
+    ) {
+      CafeSearchDetail()
     }
   }
 }

--- a/Projects/Coffice/Sources/App/Main/Search/CafeMapCore.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeMapCore.swift
@@ -22,6 +22,8 @@ struct CafeMapCore: ReducerProtocol {
     case outlet
     case spaceSize
     case personnel
+    // TODO: 테스트용 코드로 제거 예정
+    case searchDetail
 
     var title: String {
       switch self {
@@ -29,6 +31,8 @@ struct CafeMapCore: ReducerProtocol {
       case .outlet: return "콘센트"
       case .spaceSize: return "공간크기"
       case .personnel: return "인원"
+      // TODO: 테스트용 코드로 제거 예정
+      case .searchDetail: return "검색상세"
       }
     }
   }
@@ -70,6 +74,8 @@ struct CafeMapCore: ReducerProtocol {
     case searchTextFieldTyped(text: String)
     case searchTextFieldClearButtonClicked
     case searchTextSubmitted
+    // TODO: 임시 테스트 코드 작성
+    case pushToSearchDetailForTest
   }
 
   @Dependency(\.locationManager) private var locationManager
@@ -122,9 +128,14 @@ struct CafeMapCore: ReducerProtocol {
           await send(.fetchCurrentLocation)
         }
 
-      case .filterOrderMenuClicked:
+      case .filterOrderMenuClicked(let filterOrder):
         // TODO: 필터 메뉴에 따른 이벤트 처리 필요
-        return .none
+        switch filterOrder {
+        case .searchDetail:
+          return EffectTask(value: .pushToSearchDetailForTest)
+        default:
+          return .none
+        }
 
       case .searchTextFieldTyped(let text):
         state.searchText = text

--- a/Projects/Coffice/Sources/App/Main/Search/CafeSearchDetailCore.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeSearchDetailCore.swift
@@ -1,0 +1,58 @@
+//
+//  CafeSearchDetailCore.swift
+//  coffice
+//
+//  Created by Min Min on 2023/06/24.
+//  Copyright © 2023 kr.co.yapp. All rights reserved.
+//
+
+import ComposableArchitecture
+import Foundation
+
+struct CafeSearchDetail: ReducerProtocol {
+  enum SubMenuType: CaseIterable {
+    case home
+    case detailInfo
+    case review
+
+    var title: String {
+      switch self {
+      case .home: return "홈"
+      case .detailInfo: return "세부정보"
+      case .review: return "리뷰"
+      }
+    }
+  }
+
+  struct State: Equatable {
+    let title = "CafeSearchDetail"
+    let subMenus = SubMenuType.allCases
+    var selectedSubMenuType: SubMenuType = .home
+    var homeMenuViewHeight: CGFloat = 300.0
+  }
+
+  enum Action: Equatable {
+    case onAppear
+    case subMenuTapped(SubMenuType)
+    case updateHomeMenuViewHeight
+  }
+
+  @Dependency(\.apiClient) private var apiClient
+
+  var body: some ReducerProtocolOf<CafeSearchDetail> {
+    Reduce { state, action in
+      switch action {
+      case .onAppear:
+        return .none
+
+      case .subMenuTapped(let menuType):
+        state.selectedSubMenuType = menuType
+        return .none
+
+      case .updateHomeMenuViewHeight:
+        state.homeMenuViewHeight = 500
+        return .none
+      }
+    }
+  }
+}

--- a/Projects/Coffice/Sources/App/Main/Search/CafeSearchDetailCore.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeSearchDetailCore.swift
@@ -28,14 +28,24 @@ struct CafeSearchDetail: ReducerProtocol {
     let title = "CafeSearchDetail"
     let subMenus = SubMenuType.allCases
     var selectedSubMenuType: SubMenuType = .home
-    var homeMenuViewHeight: CGFloat = 300.0
+    let homeMenuViewHeight: CGFloat = 100.0
+    let openTimeDescription = """
+                      월 09:00 - 21:00
+                      화 09:00 - 21:00
+                      수 09:00 - 21:00
+                      목 09:00 - 21:00
+                      금 정기휴무 (매주 금요일)
+                      일 09:00 - 21:00
+                      """
+    var textForTest = ""
+    var needToPresentTextForTest = false
   }
 
   enum Action: Equatable {
     case onAppear
     case popView
     case subMenuTapped(SubMenuType)
-    case updateHomeMenuViewHeight
+    case toggleToPresentTextForTest
   }
 
   @Dependency(\.apiClient) private var apiClient
@@ -50,8 +60,14 @@ struct CafeSearchDetail: ReducerProtocol {
         state.selectedSubMenuType = menuType
         return .none
 
-      case .updateHomeMenuViewHeight:
-        state.homeMenuViewHeight = 500
+      case .toggleToPresentTextForTest:
+        state.needToPresentTextForTest.toggle()
+
+        if state.needToPresentTextForTest {
+          state.textForTest = state.openTimeDescription
+        } else {
+          state.textForTest = ""
+        }
         return .none
 
       default:

--- a/Projects/Coffice/Sources/App/Main/Search/CafeSearchDetailCore.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeSearchDetailCore.swift
@@ -33,6 +33,7 @@ struct CafeSearchDetail: ReducerProtocol {
 
   enum Action: Equatable {
     case onAppear
+    case popView
     case subMenuTapped(SubMenuType)
     case updateHomeMenuViewHeight
   }
@@ -51,6 +52,9 @@ struct CafeSearchDetail: ReducerProtocol {
 
       case .updateHomeMenuViewHeight:
         state.homeMenuViewHeight = 500
+        return .none
+
+      default:
         return .none
       }
     }

--- a/Projects/Coffice/Sources/App/Main/Search/CafeSearchDetailView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeSearchDetailView.swift
@@ -134,30 +134,40 @@ struct CafeSearchDetailView: View {
   private var homeMenuView: some View {
     WithViewStore(store) { viewStore in
       VStack(spacing: 0) {
-        Color.red
-          .frame(height: 200)
-        Color.black
-          .frame(height: viewStore.homeMenuViewHeight)
-          .onTapGesture {
-            viewStore.send(.updateHomeMenuViewHeight)
+        Button {
+          viewStore.send(.toggleToPresentTextForTest)
+        } label: {
+          HStack {
+            Text("토 09:00 - 21:00")
+              .foregroundColor(.black)
+              .frame(maxWidth: .infinity)
+
+            if viewStore.needToPresentTextForTest {
+              Image(systemName: "chevron.up")
+                .tint(Color.black)
+            } else {
+              Image(systemName: "chevron.down")
+                .tint(Color.black)
+            }
           }
-        Color.green
-          .frame(height: 500)
+          .padding(.horizontal, 16)
+        }
+
+        Text(viewStore.textForTest)
       }
+      .padding(.top, 10)
     }
   }
 
   private var detailInfoMenuView: some View {
     VStack(spacing: 0) {
-      Color.black
-        .frame(height: CGFloat.random(in: 300...2000))
+      EmptyView()
     }
   }
 
   private var reviewMenuView: some View {
     VStack(spacing: 0) {
-      Color.black
-        .frame(height: CGFloat.random(in: 500...1000))
+      EmptyView()
     }
   }
 }

--- a/Projects/Coffice/Sources/App/Main/Search/CafeSearchDetailView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeSearchDetailView.swift
@@ -1,0 +1,165 @@
+//
+//  CafeSearchDetailView.swift
+//  coffice
+//
+//  Created by Min Min on 2023/06/24.
+//  Copyright © 2023 kr.co.yapp. All rights reserved.
+//
+
+import ComposableArchitecture
+import SwiftUI
+
+struct CafeSearchDetailView: View {
+  private let store: StoreOf<CafeSearchDetail>
+
+  init(store: StoreOf<CafeSearchDetail>) {
+    self.store = store
+  }
+
+  var body: some View {
+    mainView
+  }
+
+  var mainView: some View {
+    WithViewStore(store) { viewStore in
+      VStack {
+        ScrollView(.vertical) {
+          VStack(spacing: 0) {
+            headerView
+            menuContainerView
+          }
+        }
+      }
+      .customNavigationBar(centerView: {
+        Text(viewStore.title)
+      })
+    }
+  }
+
+  private var headerView: some View {
+    WithViewStore(store) { viewStore in
+      VStack(spacing: 0) {
+        Image("cafeImage")
+          .resizable()
+          .frame(height: 200)
+          .scaledToFit()
+
+        VStack(spacing: 5) {
+          Text("카페 이름")
+            .font(.title)
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+          Text("서울 용산구 ~")
+            .font(.subheadline)
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+          HStack {
+            Text("영업중")
+              .font(.subheadline)
+              .foregroundColor(.white)
+              .background(.black)
+              .cornerRadius(5)
+            Text("목 09:00 ~ 21:00")
+              .font(.subheadline)
+            Spacer()
+          }
+
+          Divider()
+
+          HStack(spacing: 0) {
+            Button {
+              // TODO: 저장하기 이벤트 구현 필요
+            } label: {
+              Text("저장하기")
+                .frame(height: 50)
+                .frame(maxWidth: .infinity)
+            }
+
+            Button {
+              // TODO: 공유하기 이벤트 구현 필요
+            } label: {
+              Text("공유하기")
+                .frame(height: 50)
+                .frame(maxWidth: .infinity)
+            }
+          }
+          .frame(maxWidth: .infinity)
+
+          Divider()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+      }
+    }
+  }
+
+  private var menuContainerView: some View {
+    WithViewStore(store) { viewStore in
+      VStack(spacing: 0) {
+        HStack(spacing: 0) {
+          ForEach(viewStore.subMenus, id: \.self) { subMenuType in
+            Button {
+              viewStore.send(.subMenuTapped(subMenuType))
+            } label: {
+              Text(subMenuType.title)
+                .frame(height: 50)
+                .frame(maxWidth: .infinity)
+            }
+          }
+        }
+
+        Divider()
+
+        switch viewStore.selectedSubMenuType {
+        case .home:
+          homeMenuView
+        case .detailInfo:
+          detailInfoMenuView
+        case .review:
+          reviewMenuView
+        }
+      }
+    }
+  }
+
+  private var homeMenuView: some View {
+    WithViewStore(store) { viewStore in
+      VStack(spacing: 0) {
+        Color.red
+          .frame(height: 200)
+        Color.black
+          .frame(height: viewStore.homeMenuViewHeight)
+          .onTapGesture {
+            viewStore.send(.updateHomeMenuViewHeight)
+          }
+        Color.green
+          .frame(height: 500)
+      }
+    }
+  }
+
+  private var detailInfoMenuView: some View {
+    VStack(spacing: 0) {
+      Color.black
+        .frame(height: CGFloat.random(in: 300...2000))
+    }
+  }
+
+  private var reviewMenuView: some View {
+    VStack(spacing: 0) {
+      Color.black
+        .frame(height: CGFloat.random(in: 500...1000))
+    }
+  }
+}
+
+struct CafeSearchDetailView_Previews: PreviewProvider {
+  static var previews: some View {
+    CafeSearchDetailView(
+      store: .init(
+        initialState: .init(),
+        reducer: CafeSearchDetail()
+      )
+    )
+  }
+}

--- a/Projects/Coffice/Sources/App/Main/Search/CafeSearchDetailView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/CafeSearchDetailView.swift
@@ -30,9 +30,18 @@ struct CafeSearchDetailView: View {
           }
         }
       }
-      .customNavigationBar(centerView: {
-        Text(viewStore.title)
-      })
+      .customNavigationBar(
+        centerView: {
+          Text(viewStore.title)
+        },
+        leftView: {
+          Button {
+            viewStore.send(.popView)
+          } label: {
+            Image(systemName: "chevron.left")
+          }
+        }
+      )
     }
   }
 

--- a/Projects/Coffice/Sources/App/Main/Search/SearchCoordinatorCore.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/SearchCoordinatorCore.swift
@@ -25,8 +25,16 @@ struct SearchCoordinator: ReducerProtocol {
   }
 
   var body: some ReducerProtocolOf<SearchCoordinator> {
-    Reduce<State, Action> { _, action in
+    Reduce<State, Action> { state, action in
       switch action {
+      case .routeAction(_, action: .cafeMap(.pushToSearchDetailForTest)):
+        state.routes.push(.cafeSearchDetail(.init()))
+        return .none
+
+      case .routeAction(_, action: .cafeSearchDetail(.popView)):
+        state.routes.pop()
+        return .none
+
       default:
         return .none
       }

--- a/Projects/Coffice/Sources/App/Main/Search/SearchCoordinatorView.swift
+++ b/Projects/Coffice/Sources/App/Main/Search/SearchCoordinatorView.swift
@@ -21,6 +21,12 @@ struct SearchCoordinatorView: View {
           action: SearchScreen.Action.cafeMap,
           then: CafeMapView.init
         )
+
+        CaseLet(
+          state: /SearchScreen.State.cafeSearchDetail,
+          action: SearchScreen.Action.cafeSearchDetail,
+          then: CafeSearchDetailView.init
+        )
       }
     }
   }


### PR DESCRIPTION
## ☕️ PR 요약
- 카페 검색결과 상세페이지 파일 추가
- 헤더, 메뉴화면 기본 구조 구성
  - 3개의 메뉴 뷰의 높이를 랜덤하게 설정했을때 잘 표출되는지 UI 높이 변동 테스트코드 임시 작성 (화면만 추가하고 진입점이 없으므로, 현 앱에 사이드 이펙트 없음)
  - 테스트 방법 : SearchCoordinator의 root를 cafeMap -> cafeSearchDetail로 변경하여 화면 확인 가능